### PR TITLE
[CONFIG] rework granel routing configuration

### DIFF
--- a/assets/scripts/router.es6
+++ b/assets/scripts/router.es6
@@ -4,17 +4,16 @@ let container = document.querySelector('.container');
    un click sur une div et en chargeant le template de la page suivante dans le container,
 */
 
-document.querySelector(".link").addEventListener("click", function(){
-    callLoad();
-});
+// document.querySelector(".link").addEventListener("click", function(e){
+//     callLoad();
+// });
 
-function callLoad(){
-     getTemplate("page-project", "tropical");
- }
+// function callLoad(){
+//      getTemplate("page-project", "tropical");
+//  }
 
  function getTemplate(name, id) {
      let template = require('../../assets/html/' + name + '.html');
-     let container = document.querySelector('.container');
      let xhr = new XMLHttpRequest();
      xhr.open('GET', '../../assets/html/' + name + '.html', false);
      xhr.onreadystatechange = function() {
@@ -24,12 +23,9 @@ function callLoad(){
              var compile = template();
          }
          container.innerHTML += compile;
+        listenClicks(container);
      };
      xhr.send();
-
-     document.querySelector(".link").addEventListener("click", function(){
-         callLoad();
-     });
  };
 
 /* Système de route fonctionnel (renvoie le bon template et les bons paramètres etc)
@@ -37,25 +33,36 @@ mais qui ne permet pas d'append un template à la suite d'un autre au sein du m�
 (la page se recharge, et le template est chargé dans le container vide de l'index.html)
  */
  
-// var routes = {
-//     '/projects/:id': function(req) {
-//         getTemplate('page-project', req.params.id);
-//     },
-//     '/': function(req) {
-//         getTemplate('page-home');
-//         var home = require('../../assets/scripts/page-home.es6');
-//     },
-//     '/*': function(req, e) {
-//         if (!e.parent()) {
-//             getTemplate('404');
-//         }
-//     }
-// }
-//
-// Grapnel.listen({
-//     pushState: true
-// }, routes);
+var router = new Grapnel({
+    pushState: true
+});
 
+router.get('/projects/:id', function(req) {
+    getTemplate('page-project', req.params.id);
+});
+
+router.get('/', function(req) {
+    getTemplate('page-home');
+    var home = require('../../assets/scripts/page-home.es6');
+});
+
+router.get('/*', function(req, e) {
+    if (!e.parent()) {
+        getTemplate('404');
+    }
+});
+
+// Listen for clicks to navigate
+function listenClicks(element) {
+  var links = element.getElementsByTagName('a');
+  for (let i = 0; i < links.length; i++) {
+    links[i].addEventListener('click', function(e) {
+      e.preventDefault();
+      router.navigate(e.target.pathname);
+    });
+  }
+}
+listenClicks(document);
 
 // function getHeader(page) {
 //     console.log(page);

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <!-- Container utilisé pour injecter les différents templates -->
     <section class="container">
-        <a href="/home">Home</a>
+        <a href="/">Home</a>
         <a href="/projects/tropical">Tropical</a>
         <div class="link"> Appel template page-project</div>
     </section>


### PR DESCRIPTION
J'ai simplement changé la manière de déclarer les routes, en m'inspirant fortement d'un code qui fonctionnait et que je vous avais partagé par mail : https://github.com/bcalou/hetic-p2019/blob/316ccbdc893c9d0559ae3df04c2a2376a95eb012/index.html

La différence majeure ici est que l'on écoute "manuellement" les liens (fonction listenClicks). Lorsqu'un lien est cliqué, on utilise `preventDefault` pour ne pas changer de page et `router.navigate` pour demander explicitement à grapnel de faire le routing à la place.

Pour le moment ce code ajoute le nouveau template à la page existante (`container.innerHTML += compile`), je n'ai pas touché à ça mais il y aura sans doute des adaptations à faire j'imagine !

Par ailleurs, pourquoi charger le header en AJAX et ne pas l'intégrer directement à l'index.html ?

Bref, testez et si vous êtes bloqués à nouveau n'hésitez pas. Bonne chance :)

PS : j'ai aussi changé la route `/home` en `/`, par convention.